### PR TITLE
changed onListen and onCancel to be nullable

### DIFF
--- a/android/src/main/kotlin/com/elyudde/sms_advanced/SmsReceiver.kt
+++ b/android/src/main/kotlin/com/elyudde/sms_advanced/SmsReceiver.kt
@@ -34,7 +34,7 @@ internal class SmsReceiver(val context: Context, private val binding: ActivityPl
     private var sink: EventSink? = null
 
     @TargetApi(Build.VERSION_CODES.KITKAT)
-    override fun onListen(arguments: Any, events: EventSink) {
+    override fun onListen(arguments: Any?, events: EventSink) {
         receiver = createSmsReceiver(events)
         context
             .registerReceiver(receiver, IntentFilter(Telephony.Sms.Intents.SMS_RECEIVED_ACTION))
@@ -42,7 +42,7 @@ internal class SmsReceiver(val context: Context, private val binding: ActivityPl
         permissions.checkAndRequestPermission(permissionsList, Permissions.RECV_SMS_ID_REQ)
     }
 
-    override fun onCancel(o: Any) {
+    override fun onCancel(o: Any?) {
         context.unregisterReceiver(receiver)
         receiver = null
     }


### PR DESCRIPTION
there was a exception raised when trying to use  onSmsReceived as a stream 
so after some research i found that it was raised cause of the methods onListen and onCancel not accepting null arguments 