### PR TITLE
changed buildscript ext.kotlin_ver to 1.5.20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.elyudde.sms_advanced'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Hey,

Fix in regard to the following error during build:

> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
> The following dependencies do not satisfy the required version:
> project ':sms_advanced' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50